### PR TITLE
[기능] 구글 스프레드 시트 내 데이터를 노드가 읽는 기능 추가

### DIFF
--- a/ProjectP/Assets/01.Scenes/TestScene/ChoMinHyeong/JMH_TestScene.unity
+++ b/ProjectP/Assets/01.Scenes/TestScene/ChoMinHyeong/JMH_TestScene.unity
@@ -119,6 +119,237 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &18915001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 18915003}
+  - component: {fileID: 18915002}
+  m_Layer: 0
+  m_Name: DamageNodeLoader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &18915002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 18915001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 32ff060ea8cb5dd4ba0b76471719f400, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::MovementSpeedNodeLoader
+  _url: https://docs.google.com/spreadsheets/d/1kg7q9cQNKw5tksgh9pD_iVCW6uLvrzECEi2y9duVHLY/edit?gid=1430081326#gid=1430081326
+  _gid: 1430081326
+  _dataContainer: {fileID: 11400000, guid: 5fc1e4e5689101a4fbbf46417c66112b, type: 2}
+  _treeView: {fileID: 1595255951}
+--- !u!4 &18915003
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 18915001}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 410344656}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &223871207
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 223871208}
+  - component: {fileID: 223871209}
+  m_Layer: 0
+  m_Name: EvasionRateNodeLoader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &223871208
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 223871207}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 410344656}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &223871209
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 223871207}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 32ff060ea8cb5dd4ba0b76471719f400, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::NodeLoader
+  _url: https://docs.google.com/spreadsheets/d/1kg7q9cQNKw5tksgh9pD_iVCW6uLvrzECEi2y9duVHLY/edit?gid=994647618#gid=994647618
+  _gid: 994647618
+  _dataContainer: {fileID: 11400000, guid: d4fa68046a244fb479122eaea614aeca, type: 2}
+  _treeView: {fileID: 1595255951}
+--- !u!1 &410344655
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 410344656}
+  m_Layer: 0
+  m_Name: NodeLoaders
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &410344656
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 410344655}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 18915003}
+  - {fileID: 1006738069}
+  - {fileID: 1473130494}
+  - {fileID: 1073329832}
+  - {fileID: 972255257}
+  - {fileID: 223871208}
+  - {fileID: 1114719819}
+  - {fileID: 1330962789}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &972255255
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 972255257}
+  - component: {fileID: 972255256}
+  m_Layer: 0
+  m_Name: MovementSpeedNodeLoader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &972255256
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 972255255}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 32ff060ea8cb5dd4ba0b76471719f400, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::MoveSpeedNodeLoader
+  _url: https://docs.google.com/spreadsheets/d/1kg7q9cQNKw5tksgh9pD_iVCW6uLvrzECEi2y9duVHLY/edit?gid=636585821#gid=636585821
+  _gid: 636585821
+  _dataContainer: {fileID: 11400000, guid: ebbfe3943b25464499fd522ce34a3898, type: 2}
+  _treeView: {fileID: 1595255951}
+--- !u!4 &972255257
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 972255255}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 410344656}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1006738067
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1006738069}
+  - component: {fileID: 1006738068}
+  m_Layer: 0
+  m_Name: AttackSpeedNodeLoader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1006738068
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1006738067}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 32ff060ea8cb5dd4ba0b76471719f400, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::NodeLoader
+  _url: https://docs.google.com/spreadsheets/d/1kg7q9cQNKw5tksgh9pD_iVCW6uLvrzECEi2y9duVHLY/edit?gid=7667405#gid=7667405
+  _gid: 7667405
+  _dataContainer: {fileID: 11400000, guid: 0f19bdd2c0da02b4f966e32177b5921c, type: 2}
+  _treeView: {fileID: 1595255951}
+--- !u!4 &1006738069
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1006738067}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 410344656}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1038779603
 GameObject:
   m_ObjectHideFlags: 0
@@ -256,6 +487,198 @@ MonoBehaviour:
     m_VarianceClampScale: 0.9
     m_ContrastAdaptiveSharpening: 0
   m_Version: 2
+--- !u!1 &1073329831
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1073329832}
+  - component: {fileID: 1073329833}
+  m_Layer: 0
+  m_Name: CriticalDamageNodeLoader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1073329832
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1073329831}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 410344656}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1073329833
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1073329831}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 32ff060ea8cb5dd4ba0b76471719f400, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::NodeLoader
+  _url: https://docs.google.com/spreadsheets/d/1kg7q9cQNKw5tksgh9pD_iVCW6uLvrzECEi2y9duVHLY/edit?gid=227604789#gid=227604789
+  _gid: 227604789
+  _dataContainer: {fileID: 11400000, guid: 9ed6b41323c05d747aaee8104188d1b6, type: 2}
+  _treeView: {fileID: 1595255951}
+--- !u!1 &1114719818
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1114719819}
+  - component: {fileID: 1114719820}
+  m_Layer: 0
+  m_Name: MaxHPNodeLoader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1114719819
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1114719818}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 410344656}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1114719820
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1114719818}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 32ff060ea8cb5dd4ba0b76471719f400, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::NodeLoader
+  _url: https://docs.google.com/spreadsheets/d/1kg7q9cQNKw5tksgh9pD_iVCW6uLvrzECEi2y9duVHLY/edit?gid=924749920#gid=924749920
+  _gid: 924749920
+  _dataContainer: {fileID: 11400000, guid: 32d727a72900fcd4bb2e17a09a4beec9, type: 2}
+  _treeView: {fileID: 1595255951}
+--- !u!1 &1330962788
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1330962789}
+  - component: {fileID: 1330962790}
+  m_Layer: 0
+  m_Name: ProjecttileCountNodeLoader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1330962789
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1330962788}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 410344656}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1330962790
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1330962788}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 32ff060ea8cb5dd4ba0b76471719f400, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::NodeLoader
+  _url: https://docs.google.com/spreadsheets/d/1kg7q9cQNKw5tksgh9pD_iVCW6uLvrzECEi2y9duVHLY/edit?gid=1503602691#gid=1503602691
+  _gid: 1503602691
+  _dataContainer: {fileID: 11400000, guid: 0c40b3718d7ce0344b2525cb68700cf6, type: 2}
+  _treeView: {fileID: 1595255951}
+--- !u!1 &1473130493
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1473130494}
+  - component: {fileID: 1473130495}
+  m_Layer: 0
+  m_Name: CriticalRateNodeLoader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1473130494
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1473130493}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 410344656}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1473130495
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1473130493}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 32ff060ea8cb5dd4ba0b76471719f400, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::NodeLoader
+  _url: https://docs.google.com/spreadsheets/d/1kg7q9cQNKw5tksgh9pD_iVCW6uLvrzECEi2y9duVHLY/edit?gid=695641258#gid=695641258
+  _gid: 695641258
+  _dataContainer: {fileID: 11400000, guid: 83028cb081bb6f448aefa808390e49ea, type: 2}
+  _treeView: {fileID: 1595255951}
 --- !u!1 &1595255948
 GameObject:
   m_ObjectHideFlags: 0
@@ -326,66 +749,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::StatTreeView
   statGraph: {fileID: 11400000, guid: fe94c6b73152571479b7052435a7c1c8, type: 2}
   nodeTemplate: {fileID: 9197481963319205126, guid: 3b0db938a3f75f842b52b2ab700dc452, type: 3}
---- !u!1 &1790196599
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1790196602}
-  - component: {fileID: 1790196601}
-  - component: {fileID: 1790196600}
-  m_Layer: 0
-  m_Name: VisualScripting SceneVariables
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1790196600
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1790196599}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 765181c9ef4b24d32a4f7cbd2ef370dc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Unity.VisualScripting.Core::Unity.VisualScripting.SceneVariables
---- !u!114 &1790196601
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1790196599}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e741851cba3ad425c91ecf922cc6b379, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Unity.VisualScripting.Core::Unity.VisualScripting.Variables
-  _data:
-    _json: '{"declarations":{"Kind":"Scene","collection":{"$content":[],"$version":"A"},"$version":"A"}}'
-    _objectReferences: []
---- !u!4 &1790196602
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1790196599}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1807931158
 GameObject:
   m_ObjectHideFlags: 0
@@ -431,11 +794,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StatNodeManager
   _statNodeGraph: {fileID: 11400000, guid: fe94c6b73152571479b7052435a7c1c8, type: 2}
+  _openNodePoint: 0
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 1038779606}
-  - {fileID: 1790196602}
   - {fileID: 1807931159}
   - {fileID: 1595255950}
+  - {fileID: 410344656}

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/AttackSpeedNodeDataSO.asset
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/AttackSpeedNodeDataSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 115ab1c23587dce4db8c78b3c19a2125, type: 3}
+  m_Name: AttackSpeedNodeDataSO
+  m_EditorClassIdentifier: Assembly-CSharp::NodeDataSO

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/AttackSpeedNodeDataSO.asset.meta
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/AttackSpeedNodeDataSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0f19bdd2c0da02b4f966e32177b5921c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/CriticalDamageNodeDataSO.asset
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/CriticalDamageNodeDataSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 115ab1c23587dce4db8c78b3c19a2125, type: 3}
+  m_Name: CriticalDamageNodeDataSO
+  m_EditorClassIdentifier: Assembly-CSharp::NodeDataSO

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/CriticalDamageNodeDataSO.asset.meta
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/CriticalDamageNodeDataSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9ed6b41323c05d747aaee8104188d1b6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/CriticalRateNodeDataSO.asset
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/CriticalRateNodeDataSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 115ab1c23587dce4db8c78b3c19a2125, type: 3}
+  m_Name: CriticalRateNodeDataSO
+  m_EditorClassIdentifier: Assembly-CSharp::NodeDataSO

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/CriticalRateNodeDataSO.asset.meta
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/CriticalRateNodeDataSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 83028cb081bb6f448aefa808390e49ea
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/DamageNodeDataSO.asset
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/DamageNodeDataSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 115ab1c23587dce4db8c78b3c19a2125, type: 3}
+  m_Name: DamageNodeDataSO
+  m_EditorClassIdentifier: Assembly-CSharp::NodeDataSO

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/DamageNodeDataSO.asset.meta
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/DamageNodeDataSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5fc1e4e5689101a4fbbf46417c66112b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/EvasionRateNodeDataSO.asset
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/EvasionRateNodeDataSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 115ab1c23587dce4db8c78b3c19a2125, type: 3}
+  m_Name: EvasionRateNodeDataSO
+  m_EditorClassIdentifier: Assembly-CSharp::NodeDataSO

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/EvasionRateNodeDataSO.asset.meta
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/EvasionRateNodeDataSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d4fa68046a244fb479122eaea614aeca
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/MaxHPNodeDataSO.asset
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/MaxHPNodeDataSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 115ab1c23587dce4db8c78b3c19a2125, type: 3}
+  m_Name: MaxHPNodeDataSO
+  m_EditorClassIdentifier: Assembly-CSharp::NodeDataSO

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/MaxHPNodeDataSO.asset.meta
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/MaxHPNodeDataSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 32d727a72900fcd4bb2e17a09a4beec9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/MovementSpeedNodeDataSO.asset
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/MovementSpeedNodeDataSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 115ab1c23587dce4db8c78b3c19a2125, type: 3}
+  m_Name: MovementSpeedNodeDataSO
+  m_EditorClassIdentifier: Assembly-CSharp::NodeDataSO

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/MovementSpeedNodeDataSO.asset.meta
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/MovementSpeedNodeDataSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ebbfe3943b25464499fd522ce34a3898
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/New Stat Node Graph.asset
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/New Stat Node Graph.asset
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-7235488384103998433
+--- !u!114 &-6618331855953182602
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -13,14 +13,14 @@ MonoBehaviour:
   m_Name: Stat
   m_EditorClassIdentifier: Assembly-CSharp::StatNode
   graph: {fileID: 11400000}
-  position: {x: 100, y: 100}
+  position: {x: 616, y: 120}
   ports:
     keys:
-    - input
-    - output
+    - Input
+    - Output
     values:
-    - _fieldName: input
-      _node: {fileID: -7235488384103998433}
+    - _fieldName: Input
+      _node: {fileID: -6618331855953182602}
       _typeQualifiedName: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral,
         PublicKeyToken=b77a5c561934e089
       connections: []
@@ -28,22 +28,142 @@ MonoBehaviour:
       _connectionType: 0
       _typeConstraint: 0
       _dynamic: 0
-    - _fieldName: output
-      _node: {fileID: -7235488384103998433}
+    - _fieldName: Output
+      _node: {fileID: -6618331855953182602}
       _typeQualifiedName: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral,
         PublicKeyToken=b77a5c561934e089
-      connections:
-      - fieldName: input
-        node: {fileID: 2389273493957553678}
-        reroutePoints: []
+      connections: []
       _direction: 1
       _connectionType: 0
       _typeConstraint: 0
       _dynamic: 0
-  input: 0
-  output: 0
-  nodeName: "\uCCB4\uB825 \uC99D\uAC00"
-  value: 10
+  Input: 0
+  Output: 0
+  _nodeId: 10011
+  _nodeData: {fileID: 11400000, guid: 0f19bdd2c0da02b4f966e32177b5921c, type: 2}
+--- !u!114 &-6404034487812361814
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25fca505dcad5de49b29c8867a8bed64, type: 3}
+  m_Name: Stat
+  m_EditorClassIdentifier: Assembly-CSharp::StatNode
+  graph: {fileID: 11400000}
+  position: {x: 392, y: 264}
+  ports:
+    keys:
+    - Input
+    - Output
+    values:
+    - _fieldName: Input
+      _node: {fileID: -6404034487812361814}
+      _typeQualifiedName: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+      connections: []
+      _direction: 0
+      _connectionType: 0
+      _typeConstraint: 0
+      _dynamic: 0
+    - _fieldName: Output
+      _node: {fileID: -6404034487812361814}
+      _typeQualifiedName: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+      connections: []
+      _direction: 1
+      _connectionType: 0
+      _typeConstraint: 0
+      _dynamic: 0
+  Input: 0
+  Output: 0
+  _nodeId: 10031
+  _nodeData: {fileID: 11400000, guid: 83028cb081bb6f448aefa808390e49ea, type: 2}
+--- !u!114 &-6389532710573848279
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25fca505dcad5de49b29c8867a8bed64, type: 3}
+  m_Name: Stat
+  m_EditorClassIdentifier: Assembly-CSharp::StatNode
+  graph: {fileID: 11400000}
+  position: {x: 616, y: 408}
+  ports:
+    keys:
+    - Input
+    - Output
+    values:
+    - _fieldName: Input
+      _node: {fileID: -6389532710573848279}
+      _typeQualifiedName: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+      connections: []
+      _direction: 0
+      _connectionType: 0
+      _typeConstraint: 0
+      _dynamic: 0
+    - _fieldName: Output
+      _node: {fileID: -6389532710573848279}
+      _typeQualifiedName: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+      connections: []
+      _direction: 1
+      _connectionType: 0
+      _typeConstraint: 0
+      _dynamic: 0
+  Input: 0
+  Output: 0
+  _nodeId: 10061
+  _nodeData: {fileID: 11400000, guid: d4fa68046a244fb479122eaea614aeca, type: 2}
+--- !u!114 &-2362383482836844827
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25fca505dcad5de49b29c8867a8bed64, type: 3}
+  m_Name: Stat
+  m_EditorClassIdentifier: Assembly-CSharp::StatNode
+  graph: {fileID: 11400000}
+  position: {x: 616, y: 264}
+  ports:
+    keys:
+    - Input
+    - Output
+    values:
+    - _fieldName: Input
+      _node: {fileID: -2362383482836844827}
+      _typeQualifiedName: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+      connections: []
+      _direction: 0
+      _connectionType: 0
+      _typeConstraint: 0
+      _dynamic: 0
+    - _fieldName: Output
+      _node: {fileID: -2362383482836844827}
+      _typeQualifiedName: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+      connections: []
+      _direction: 1
+      _connectionType: 0
+      _typeConstraint: 0
+      _dynamic: 0
+  Input: 0
+  Output: 0
+  _nodeId: 10041
+  _nodeData: {fileID: 11400000, guid: 9ed6b41323c05d747aaee8104188d1b6, type: 2}
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -57,9 +177,15 @@ MonoBehaviour:
   m_Name: New Stat Node Graph
   m_EditorClassIdentifier: Assembly-CSharp::StatNodeGraph
   nodes:
-  - {fileID: -7235488384103998433}
-  - {fileID: 2389273493957553678}
---- !u!114 &2389273493957553678
+  - {fileID: 2905345672599395674}
+  - {fileID: -6618331855953182602}
+  - {fileID: -6404034487812361814}
+  - {fileID: -2362383482836844827}
+  - {fileID: 215669569877078486}
+  - {fileID: -6389532710573848279}
+  - {fileID: 1964596176363336805}
+  - {fileID: 2223741274942106020}
+--- !u!114 &215669569877078486
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -72,26 +198,23 @@ MonoBehaviour:
   m_Name: Stat
   m_EditorClassIdentifier: Assembly-CSharp::StatNode
   graph: {fileID: 11400000}
-  position: {x: 392, y: 100}
+  position: {x: 392, y: 408}
   ports:
     keys:
-    - input
-    - output
+    - Input
+    - Output
     values:
-    - _fieldName: input
-      _node: {fileID: 2389273493957553678}
+    - _fieldName: Input
+      _node: {fileID: 215669569877078486}
       _typeQualifiedName: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral,
         PublicKeyToken=b77a5c561934e089
-      connections:
-      - fieldName: output
-        node: {fileID: -7235488384103998433}
-        reroutePoints: []
+      connections: []
       _direction: 0
       _connectionType: 0
       _typeConstraint: 0
       _dynamic: 0
-    - _fieldName: output
-      _node: {fileID: 2389273493957553678}
+    - _fieldName: Output
+      _node: {fileID: 215669569877078486}
       _typeQualifiedName: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral,
         PublicKeyToken=b77a5c561934e089
       connections: []
@@ -99,7 +222,130 @@ MonoBehaviour:
       _connectionType: 0
       _typeConstraint: 0
       _dynamic: 0
-  input: 0
-  output: 0
-  nodeName: "\uB370\uBBF8\uC9C0 \uC99D\uAC00"
-  value: 10
+  Input: 0
+  Output: 0
+  _nodeId: 10051
+  _nodeData: {fileID: 11400000, guid: ebbfe3943b25464499fd522ce34a3898, type: 2}
+--- !u!114 &1964596176363336805
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25fca505dcad5de49b29c8867a8bed64, type: 3}
+  m_Name: Stat
+  m_EditorClassIdentifier: Assembly-CSharp::StatNode
+  graph: {fileID: 11400000}
+  position: {x: 840, y: 264}
+  ports:
+    keys:
+    - Input
+    - Output
+    values:
+    - _fieldName: Input
+      _node: {fileID: 1964596176363336805}
+      _typeQualifiedName: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+      connections: []
+      _direction: 0
+      _connectionType: 0
+      _typeConstraint: 0
+      _dynamic: 0
+    - _fieldName: Output
+      _node: {fileID: 1964596176363336805}
+      _typeQualifiedName: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+      connections: []
+      _direction: 1
+      _connectionType: 0
+      _typeConstraint: 0
+      _dynamic: 0
+  Input: 0
+  Output: 0
+  _nodeId: 10071
+  _nodeData: {fileID: 11400000, guid: 32d727a72900fcd4bb2e17a09a4beec9, type: 2}
+--- !u!114 &2223741274942106020
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25fca505dcad5de49b29c8867a8bed64, type: 3}
+  m_Name: Stat
+  m_EditorClassIdentifier: Assembly-CSharp::StatNode
+  graph: {fileID: 11400000}
+  position: {x: 840, y: 408}
+  ports:
+    keys:
+    - Input
+    - Output
+    values:
+    - _fieldName: Input
+      _node: {fileID: 2223741274942106020}
+      _typeQualifiedName: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+      connections: []
+      _direction: 0
+      _connectionType: 0
+      _typeConstraint: 0
+      _dynamic: 0
+    - _fieldName: Output
+      _node: {fileID: 2223741274942106020}
+      _typeQualifiedName: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+      connections: []
+      _direction: 1
+      _connectionType: 0
+      _typeConstraint: 0
+      _dynamic: 0
+  Input: 0
+  Output: 0
+  _nodeId: 10081
+  _nodeData: {fileID: 11400000, guid: 0c40b3718d7ce0344b2525cb68700cf6, type: 2}
+--- !u!114 &2905345672599395674
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25fca505dcad5de49b29c8867a8bed64, type: 3}
+  m_Name: Stat
+  m_EditorClassIdentifier: Assembly-CSharp::StatNode
+  graph: {fileID: 11400000}
+  position: {x: 392, y: 120}
+  ports:
+    keys:
+    - Input
+    - Output
+    values:
+    - _fieldName: Input
+      _node: {fileID: 2905345672599395674}
+      _typeQualifiedName: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+      connections: []
+      _direction: 0
+      _connectionType: 0
+      _typeConstraint: 0
+      _dynamic: 0
+    - _fieldName: Output
+      _node: {fileID: 2905345672599395674}
+      _typeQualifiedName: System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+      connections: []
+      _direction: 1
+      _connectionType: 0
+      _typeConstraint: 0
+      _dynamic: 0
+  Input: 0
+  Output: 0
+  _nodeId: 10001
+  _nodeData: {fileID: 11400000, guid: 5fc1e4e5689101a4fbbf46417c66112b, type: 2}

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/NodeDataSO.cs
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/NodeDataSO.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "NodeDataSO", menuName = "Scriptable Objects/NodeDataSO")]
+public class NodeDataSO : ScriptableObject
+{
+    // 구글 스프레드 시트 파일 내 데이터를 담을 변수
+    [SerializeField] public List<NodeInfo> NodeInfos = new List<NodeInfo>();
+}

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/NodeDataSO.cs.meta
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/NodeDataSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 115ab1c23587dce4db8c78b3c19a2125

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/NodeInfo.cs
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/NodeInfo.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+public class NodeInfo: ISheetParsable, IIdentifiable
+{
+    // 구글 시트에서 가져온 데이터를 저장할 변수
+    private string _nodeStatType;
+    private string _nameVariable;
+    private int _id;
+    private int _nodeLevel;
+    private int _nodeCostPoint;
+    private int _nodeIncrValue;
+    
+    // getter
+    public string NodeStatType => _nodeStatType;
+    public string NameVariable => _nameVariable;
+    public int Id => _id;
+    public int NodeLevel => _nodeLevel;
+    public int NodeCostPoint => _nodeCostPoint;
+    public int NodeIncrValue => _nodeIncrValue;
+    
+    [field: SerializeField] public string Name { get; set; }
+    public void ApplyRowData(string[] data)
+    {
+        // 데이터가 없으면 무시
+        if (data == null || data.Length == 0) return;
+
+        // 1. 인스펙터 리스트에 표시될 '이름' 설정 (A열 값 사용)
+        Name = data[0];
+
+        // 2. 순서대로 꽂아넣기 (형변환 실패해도 0으로 들어가서 에러 안 남)
+        _nodeStatType = data[0];           // A열
+        _nameVariable = data[1];           // B열
+        int.TryParse(data[2], out _id);    // C열 (ID)
+        int.TryParse(data[3], out _nodeLevel); // D열
+        int.TryParse(data[4], out _nodeCostPoint); // E열
+        int.TryParse(data[5], out _nodeIncrValue); // F열
+    }
+}

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/NodeInfo.cs.meta
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/NodeInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: af864b3c68990e04dbc233b76dfe3a78

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/NodeLoader.cs
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/NodeLoader.cs
@@ -1,0 +1,59 @@
+using System;
+using Unity.VisualScripting;
+using UnityEngine;
+using System.Collections.Generic;
+using UnityEditor;
+public class NodeLoader : MonoBehaviour
+{
+    [Header("불러올 시트 링크 전체 입력")]
+    [SerializeField] private string _url;
+    
+    [Header("사이트 URL 끝에 gid 번호 입력")]//기본 첫 시트는 0 인거 같음 그래도 확인 필수
+    [SerializeField] private int _gid;
+
+    [Header("데이터를 저장할 타겟 SO 연결")] 
+    [SerializeField] private NodeDataSO _dataContainer;
+    
+    [Header("UI 스크립트 연결")] 
+    [SerializeField] private StatTreeView _treeView; // UI 스크립트 연결
+    
+    private SheetLoader<NodeInfo> _data;
+   
+    async void Start()
+    {
+        // 1. 로더 생성
+        _data = new SheetLoader<NodeInfo>(_url, _gid);
+        
+        // 2. 데이터가 다 로드될 때까지 기다렸다가(await) 리스트를 받아옵니다.
+        // GetDataAsync()의 반환 타입이 Task<List<charData>>이므로 await가 필수입니다.
+        List<NodeInfo> loadedList = await _data.GetDataAsync();
+        
+        // SO의 리스트를 비운 후 새로 받아온 데이터를 채움
+        if (_dataContainer != null)
+        {
+            _dataContainer.NodeInfos.Clear();
+            _dataContainer.NodeInfos.AddRange(loadedList);
+        }
+        
+        // 트리 그래프 에셋에 직접 접근하여 노드를 찾아 init 실행
+        if (_treeView != null && _treeView.statGraph != null)
+        {
+            foreach (var node in _treeView.statGraph.nodes)
+            {
+                // 노드가 StatNode 타입인 경우에만 초기화 실행
+                if (node is StatNode statNode)
+                {
+                    statNode.InitData();
+                }
+            }
+        }
+        
+        // 불러온 후 UI 새로고침
+        if (_treeView != null)
+        {
+            _treeView.GenerateTree();
+        }
+        
+    }
+
+}

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/NodeLoader.cs.meta
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/NodeLoader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 32ff060ea8cb5dd4ba0b76471719f400

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/NotUseStatNode.cs
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/NotUseStatNode.cs
@@ -1,0 +1,36 @@
+﻿/*
+using XNode;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class StatNode : Node
+{
+
+	[Input] public bool Input;
+	[Output] public bool Output;
+
+	[SerializeField] private string _nodeName;
+	[SerializeField] private int _value;
+
+	// Use this for initialization
+	protected override void Init() {
+		base.Init();
+		
+	}
+
+	// Return the correct value of an output port when requested
+	public override object GetValue(NodePort port) {
+		if (port.fieldName == "output") return this;
+		return null; // Replace this
+	}
+	
+	public string GetNodeName() {
+		return _nodeName;
+	}
+	
+	public int GetValue() {
+		return _value;
+	}
+}
+*/

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/NotUseStatNode.cs.meta
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/NotUseStatNode.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 25fca505dcad5de49b29c8867a8bed64

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/ProjectTileCountNodeDataSO.asset
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/ProjectTileCountNodeDataSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 115ab1c23587dce4db8c78b3c19a2125, type: 3}
+  m_Name: ProjectTileCountNodeDataSO
+  m_EditorClassIdentifier: Assembly-CSharp::NodeDataSO

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/ProjectTileCountNodeDataSO.asset.meta
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/ProjectTileCountNodeDataSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0c40b3718d7ce0344b2525cb68700cf6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/StatNode.cs
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/StatNode.cs
@@ -1,34 +1,43 @@
-﻿using XNode;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using XNode;
 
-public class StatNode : Node
-{
-
-	[Input] public bool input;
-	[Output] public bool output;
-
-	[SerializeField] private string nodeName;
-	[SerializeField] private int value;
+public class StatNode : Node {
+	
+	[Input] public bool Input;
+	[Output] public bool Output;
+	
+	// 노드의 고유 ID
+	[SerializeField] private int _nodeId;
+	
+	// 노드 정보를 불러올 SO
+	[SerializeField] private NodeDataSO _nodeData;
+	
+	// 현재 노드가 실제로 사용할 데이터
+	private NodeInfo _info;
 
 	// Use this for initialization
 	protected override void Init() {
 		base.Init();
+	}
+
+	public void InitData()
+	{
+		if (_nodeData == null) return;
+		
+		// SO 리스트에서 내 ID와 일치하는 데이터 찾기
+		_info = _nodeData.NodeInfos.Find(x => x.Id == _nodeId);
 		
 	}
 
 	// Return the correct value of an output port when requested
 	public override object GetValue(NodePort port) {
-		if (port.fieldName == "output") return this;
 		return null; // Replace this
 	}
-	
-	public string GetNodeName() {
-		return nodeName;
-	}
-	
-	public int GetValue() {
-		return value;
-	}
+
+	public int GetID() => _info.Id;
+	public string GetNodeName() => _info?.NameVariable;
+	public string GetNodeStatType() => _info?.NodeStatType;
+	public int GetNodeLevel() => _info.NodeLevel;
 }

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/StatNode.cs.meta
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/StatNode.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 25fca505dcad5de49b29c8867a8bed64
+guid: aef6ccb60d16758429ffafa59da98a9c

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/StatNodeManager.cs
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/StatNodeManager.cs
@@ -3,20 +3,10 @@ using UnityEngine;
 
 public class StatNodeManager : MonoBehaviour
 {
+    [Header("스탯 노드그래프 연결")]
     [SerializeField] private StatNodeGraph _statNodeGraph;
-    
-    /*
-    void Start() {
-        // 그래프 안에 있는 모든 노드를 순회하며 초기화하거나 UI를 생성합니다.
-        foreach (Node node in _statNodeGraph.nodes) {
-            StatNode statNode = node as StatNode;
-            if (statNode != null) {
-                Debug.Log($"찾은 스킬: {statNode.GetNodeName()}, 수치: {statNode.GetValue()}");
-                
-                // 여기서 실제 게임 캐릭터의 스탯에 적용하거나 
-                // UI 버튼을 생성하는 로직을 넣습니다.
-            }
-        }
-    }
-    */
+
+    [Header("보유 노드 포인트")] 
+    [SerializeField] private int _openNodePoint;
+
 }

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/StatTreeView.cs
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/StatTreeView.cs
@@ -10,7 +10,7 @@ public class StatTreeView : MonoBehaviour
 
     private VisualElement _container;
     private VisualElement _root;
-    private bool _isOpened = false; // 현재 창이 열려있는지 확인
+    private bool _isOpened = false; // 현재 창이 열려있는지 확인, 처음 시작시에는 비활성화
 
     void OnEnable()
     {
@@ -20,13 +20,12 @@ public class StatTreeView : MonoBehaviour
         
         // 처음 시작할 때는 화면에서 숨김
         _root.style.display = DisplayStyle.None;
-
-        if (statGraph != null) GenerateTree();
+        
     }
     
     void Update()
     {
-        // 키 입력 감지
+        // 테스트를 위하여 키 입력 감지시 ui 열리게끔 설계, 추후 변경 예정
         if (Keyboard.current != null && Keyboard.current.kKey.wasPressedThisFrame)
         {
             ToggleSkillTree();
@@ -43,12 +42,13 @@ public class StatTreeView : MonoBehaviour
         UnityEngine.Cursor.lockState = _isOpened ? CursorLockMode.None : CursorLockMode.Locked;
     }
 
-    void GenerateTree()
+    public void GenerateTree()
     {
         _container.Clear(); // 기존 UI 삭제
 
         foreach (Node node in statGraph.nodes)
         {
+            /*
             if (node is StatNode statNode)
             {
                 // 템플릿(Label + Button)을 새로 만듬
@@ -75,6 +75,35 @@ public class StatTreeView : MonoBehaviour
 
                 _container.Add(nodeUI);
             }
+            */
+            
+            if (node is StatNode movementNode)
+            {
+                // 템플릿(Label + Button)을 새로 만듬
+                VisualElement nodeUI = nodeTemplate.Instantiate();
+                
+                // 데이터 연결 (UXML 내부의 이름과 일치해야 함)
+                nodeUI.Q<Label>("StatName").text = movementNode.GetNodeName(); 
+                // 만약 Label에 이름을 지어줬다면 .Q<Label>("MyLabelName") 로 작성
+                
+                // 버튼 찾아서 로그 찍기 (Hierarchy에 있는 이름 기준)
+                Button btn = nodeUI.Q<Button>("UnlockBtn");
+                if (btn != null)
+                {
+                    btn.clicked += () => {
+                        // 임시로 클릭시 로그로 노드 이름과 값 출력
+                        Debug.Log($"스킬 노드 type: {movementNode.GetNodeStatType()}");
+                    };
+                }
+
+                // xnode Editor position을 Scene에 설정 
+                nodeUI.style.position = Position.Absolute;
+                nodeUI.style.left = node.position.x;
+                nodeUI.style.top = node.position.y;
+
+                _container.Add(nodeUI);
+            }
+            
         }
     }
 }

--- a/ProjectP/Assets/02.Scripts/26_03_19_JMH/StatTreeView.cs.meta
+++ b/ProjectP/Assets/02.Scripts/26_03_19_JMH/StatTreeView.cs.meta
@@ -1,2 +1,13 @@
 fileFormatVersion: 2
 guid: 2dac26e2906abec42876086166ed735b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - statGraph: {fileID: 11400000, guid: fe94c6b73152571479b7052435a7c1c8, type: 2}
+  - nodeTemplate: {fileID: 9197481963319205126, guid: dab2116a77f6fba44802c56a5dd8f7a1, type: 3}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- 구글 스프레드 시트들을 SO에 저장 후 이를 노드가 읽는 방식으로 구현
- 스프레드 시트내 고유 key값을 기반으로 해당 key가 포함된 한 열과 노드가 읽어야 할 데이터를 매칭하는 방식으로 구현
- 공격력, 크리티컬 확률, 크리티컬 데미지, 공격속도, 이동속도, 최대 HP, 회피율, 투사체 추가 총 6개의 SO 추가