### PR TITLE
[버그] 노드 포인트가 없을 경우에 노드 UI를 오픈하는 경우 노드 포인트가 정상 표시 되지 않는 현상 수정

### DIFF
--- a/ProjectP/Assets/02.Scripts/UI/StatNodeUI/UpdateNodePointUI.cs
+++ b/ProjectP/Assets/02.Scripts/UI/StatNodeUI/UpdateNodePointUI.cs
@@ -13,6 +13,7 @@ public class UpdateNodePointUI : MonoBehaviour
     private void OnEnable()
     {
         PostManager.Instance.Subscribe<string>(PostMessageKey.NodePointTextUIUpdate,UpdateText);
+        _label.text = StatNodeManager.Instance.NodePoint.ToString();
     }
 
     private void UpdateText(string pointText)


### PR DESCRIPTION
게임 처음 시작 후 노드 포인트가 없을 경우에 노드 UI를 오픈하는 경우 노드 포인트 표시 부분에 0이 아닌 New Text가 나오는 현상 (이슈리스트 41번째)

UI창 OnEnable 시에 노드 포인트 정보를 가져오도록 수정